### PR TITLE
Adding font and offset arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Imports:
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/bbc_style.R
+++ b/R/bbc_style.R
@@ -1,28 +1,46 @@
 #' Add bbc theme to ggplot chart
 #'
 #' This function allows you to add the bbc theme to your ggplotgraphics.
+#' @param font Font with which the plot is made. By default, the value is \emph{Helvetica} but Windows machines do not support this font type.
+#' @param offset Parameter that allows adding or substracting the \code{offset} value to the original font size. In particular, it modifies the size of:
+#' \itemize{
+#'   \item The chart's title
+#'   \item The chart's subtitle
+#'   \item The legend
+#'   \item The axis
+#'   \item Title of the facet-wrap
+#' }
 #' @keywords bbc_style
 #' @export
 #' @examples
+#' \dontrun{
 #' line <- ggplot(line_df, aes(x = year, y = lifeExp)) +
 #' geom_line(colour = "#007f7f", size = 1) +
 #' geom_hline(yintercept = 0, size = 1, colour="#333333") +
 #' bbc_style()
+#' }
+#'
+#'\dontrun{
+#' # Font changed to Arial and reduced by 5 points
+#' line <- ggplot(line_df, aes(x = year, y = lifeExp)) +
+#' geom_line(colour = "#007f7f", size = 1) +
+#' geom_hline(yintercept = 0, size = 1, colour="#333333") +
+#' bbc_style(font = "Arial", offset = -5)
+#' }
 
-bbc_style <- function() {
-  font <- "Helvetica"
+bbc_style <- function(font = "Helvetica", offset = 0) {
 
   ggplot2::theme(
 
   #Text format:
   #This sets the font, size, type and colour of text for the chart's title
   plot.title = ggplot2::element_text(family=font,
-                            size=28,
+                            size=28 + offset,
                             face="bold",
                             color="#222222"),
   #This sets the font, size, type and colour of text for the chart's subtitle, as well as setting a margin between the title and the subtitle
   plot.subtitle = ggplot2::element_text(family=font,
-                               size=22,
+                               size=22 + offset,
                                margin=ggplot2::margin(9,0,9,0)),
   plot.caption = ggplot2::element_blank(),
   #This leaves the caption text element empty, because it is set elsewhere in the finalise plot function
@@ -35,14 +53,14 @@ bbc_style <- function() {
   legend.title = ggplot2::element_blank(),
   legend.key = ggplot2::element_blank(),
   legend.text = ggplot2::element_text(family=font,
-                             size=18,
+                             size=18 + offset,
                              color="#222222"),
 
   #Axis format
   #This sets the text font, size and colour for the axis test, as well as setting the margins and removes lines and ticks. In some cases, axis lines and axis ticks are things we would want to have in the chart - the cookbook shows examples of how to do so.
   axis.title = ggplot2::element_blank(),
   axis.text = ggplot2::element_text(family=font,
-                           size=18,
+                           size=18 + offset,
                            color="#222222"),
   axis.text.x = ggplot2::element_text(margin=ggplot2::margin(5, b = 10)),
   axis.ticks = ggplot2::element_blank(),
@@ -58,8 +76,8 @@ bbc_style <- function() {
   #This sets the panel background as blank, removing the standard grey ggplot background colour from the plot
   panel.background = ggplot2::element_blank(),
 
-  #Strip background (#This sets the panel background for facet-wrapped plots to white, removing the standard grey ggplot background colour and sets the title size of the facet-wrap title to font size 22)
+  #Strip background (#This sets the panel background for facet-wrapped plots to white, removing the standard grey ggplot background colour and sets the title size of the facet-wrap title to font size 22 + offset)
   strip.background = ggplot2::element_rect(fill="white"),
-  strip.text = ggplot2::element_text(size  = 22,  hjust = 0)
+  strip.text = ggplot2::element_text(size  = 22 + offset,  hjust = 0)
   )
   }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A basic explanation and summary here:
 
 ### `bbc_style()`
 
-1. `bbc_style()`: has no arguments and is added to the ggplot chain after you have created a plot. What it does is generally makes text size, font and colour, axis lines, axis text and many other standard chart components into BBC style, which has been formulated together with the Visual Journalism design team. 
+1. `bbc_style()`: has two arguments and is added to the ggplot chain after you have created a plot. What it does is generally makes text size, font and colour, axis lines, axis text and many other standard chart components into BBC style, which has been formulated together with the Visual Journalism design team. The arguments allow to adjust the the font and the size of it.
 
 The function is pretty basic and does not change or adapt based on the type of chart you are making, so in some cases you will need to make additional `theme` arguments in your ggplot chain if you want to make any additions or changes to the style, for example to add or remove gridlines etc. Also note that colours for lines in the case of a line chart or bars for a bar chart, do not come out of the box from the `bbc_style` function, but need to be explicitly set in your other standard `ggplot` chart functions.
 

--- a/man/bbc_style.Rd
+++ b/man/bbc_style.Rd
@@ -4,15 +4,37 @@
 \alias{bbc_style}
 \title{Add bbc theme to ggplot chart}
 \usage{
-bbc_style()
+bbc_style(font = "Helvetica", offset = 0)
+}
+\arguments{
+\item{font}{Font with which the plot is made. By default, the value is \emph{Helvetica} but Windows machines do not support this font type.}
+
+\item{offset}{Parameter that allows adding or substracting the \code{offset} value to the original font size. In particular, it modifies the size of:
+\itemize{
+  \item The chart's title
+  \item The chart's subtitle
+  \item The legend
+  \item The axis
+  \item Title of the facet-wrap
+}}
 }
 \description{
 This function allows you to add the bbc theme to your ggplotgraphics.
 }
 \examples{
+\dontrun{
 line <- ggplot(line_df, aes(x = year, y = lifeExp)) +
 geom_line(colour = "#007f7f", size = 1) +
 geom_hline(yintercept = 0, size = 1, colour="#333333") +
 bbc_style()
+}
+
+\dontrun{
+# Font changed to Arial and reduced by 5 points
+line <- ggplot(line_df, aes(x = year, y = lifeExp)) +
+geom_line(colour = "#007f7f", size = 1) +
+geom_hline(yintercept = 0, size = 1, colour="#333333") +
+bbc_style(font = "Arial", offset = -5)
+}
 }
 \keyword{bbc_style}

--- a/man/finalise_plot.Rd
+++ b/man/finalise_plot.Rd
@@ -4,9 +4,11 @@
 \alias{finalise_plot}
 \title{Arrange alignment and save BBC ggplot chart}
 \usage{
-finalise_plot(plot_name, source_name, save_filepath, width_pixels = 640,
-  height_pixels = 450, logo_image_path = file.path(system.file("data",
-  package = "bbcggplotr"), "bbc_blocks_r.png"))
+finalise_plot(plot_name, source_name,
+  save_filepath = file.path(Sys.getenv("TMPDIR"), "tmp-nc.png"),
+  width_pixels = 640, height_pixels = 450,
+  logo_image_path = file.path(system.file("data", package = "bbplot"),
+  "placeholder.png"))
 }
 \arguments{
 \item{plot_name}{The variable name of the plot you have created that you want to format and save}
@@ -21,6 +23,9 @@ finalise_plot(plot_name, source_name, save_filepath, width_pixels = 640,
 
 \item{logo_image_path}{File path for the logo image you want to use in the right hand side of your chart,
 which needs to be a PNG file - defaults to BBC blocks image that sits within the data folder of your package}
+}
+\value{
+(Invisibly) an updated ggplot object.
 }
 \description{
 Running this function will save your plot with the correct guidelines for publication for a BBC News graphic.


### PR DESCRIPTION
This pull request is related to the issue #8. It modifies the `bbc_style` function in order to include two arguments:

- _Font_: it allows changing the font type. This is especially relevant in Windows machines since Helvetica isn't a Windows core font.
- _Offset_: Due to size differences while changing the font type, this argument add or subtract the offset amount to the current font size.